### PR TITLE
Workaround for CERT_UNTRUSTED error in npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 
 before_deploy:
   - sudo apt-get install -y npm
+  - sudo npm config set strict-ssl false  # XXX: workaround for CERT_UNTRUSTED error in npm
   - sudo npm install -g json
   - export YPSPUR_GUI_URI=`wget -q -O - https://api.github.com/repos/openspur/ypspur-gui/releases/latest | json assets[0].browser_download_url`
   - cd ${TRAVIS_BUILD_DIR} && wget $YPSPUR_GUI_URI


### PR DESCRIPTION
This workaround must be removed after upstream fix.