### PR TITLE
Fallback message if unable to get git revision

### DIFF
--- a/cmake/modules/GetGitRevision.cmake
+++ b/cmake/modules/GetGitRevision.cmake
@@ -11,14 +11,22 @@ function(get_git_revision)
 		set(GIT_REVISION "Failed to get git revision." PARENT_SCOPE)
 	endif(NOT GIT)
 
-	exec_program(${GIT} ${CMAKE_CURRENT_SOURCE_DIR}
+	exec_program(${GIT} -C "${CMAKE_CURRENT_SOURCE_DIR}"
 		ARGS "rev-parse HEAD"
 		OUTPUT_VARIABLE REVISION
+		RETURN_VALUE rev_parse_ret
 	)
-	exec_program(${GIT} ${CMAKE_CURRENT_SOURCE_DIR}
+	exec_program(${GIT} -C "${CMAKE_CURRENT_SOURCE_DIR}"
 		ARGS "rev-parse --short HEAD"
 		OUTPUT_VARIABLE REVISION_SHORT
+		RETURN_VALUE rev_parse_short_ret
 	)
+
+	# Might not be building from a git repo
+	if((NOT ${rev_parse_ret} EQUAL "0") OR (NOT ${rev_parse_short_ret} EQUAL "0"))
+		set(GIT_REVISION_SHORT "Snapshot")
+		set(GIT_REVISION "Failed to get git revision.")
+	endif()
 
 	set(GIT_REVISION_SHORT ${REVISION_SHORT} PARENT_SCOPE)
 	set(GIT_REVISION ${REVISION} PARENT_SCOPE)


### PR DESCRIPTION
This is a proposal to fix http://build.ros.org/job/Nbin_uF64__ypspur__ubuntu_focal_amd64__binary/5/ which is appears to be the cause of a failure to build packages for `ros-noetic-ypspur` and `ros-noetic-ypspur-ros`. I have not tested this change locally, but some fix needs to be released to ROS Noetic so these packages are still available in the next Noetic sync. Please take a look as soon as possible, ideally before tomorrow.

This patch:

* Uses `-C <path>` when calling `git rev-parse`
* Sets failure message when unable to get a git revision

It looks like the generated `config.h` has a value for `PROJECT_VERSION` that contains a newline.

```c++
#ifndef __CONFIG_H__
#define __CONFIG_H__

#define PROJECT_VERSION "1.17.1 (fatal: not a git repository (or any parent up to mount point /tmp)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).)"

#define YP_VENDOR_NAME "OpenSpur.org"

#define YP_PRODUCT_NAME "Yamabico Project - Spur"

#define YP_PROTOCOL_NAME "YPP:11:05"

#define YP_PARAMS_DIR "robot-params"

/* #undef HAVE_SSM */

#define HAVE_LONGJMP 1

#define HAVE_SIGLONGJMP 1

#endif
```

Resulting in this compile error.

```
/tmp/binarydeb/ros-noetic-ypspur-1.18.1/obj-x86_64-linux-gnu/include/config.h:4:25: warning: missing terminating " character
    4 | #define PROJECT_VERSION "1.17.1 (fatal: not a git repository (or any parent up to mount point /tmp)
      |                         ^
/tmp/binarydeb/ros-noetic-ypspur-1.18.1/obj-x86_64-linux-gnu/include/config.h:5:1: error: unknown type name ‘Stopping’
    5 | Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).)"
      | ^~~~~~~~
/tmp/binarydeb/ros-noetic-ypspur-1.18.1/obj-x86_64-linux-gnu/include/config.h:5:13: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘filesystem’
    5 | Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).)"
      |             ^~~~~~~~~~
/tmp/binarydeb/ros-noetic-ypspur-1.18.1/obj-x86_64-linux-gnu/include/config.h:5:13: error: unknown type name ‘filesystem’
/tmp/binarydeb/ros-noetic-ypspur-1.18.1/obj-x86_64-linux-gnu/include/config.h:5:76: warning: missing terminating " character
    5 | Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).)"
      |                                                                            ^
/tmp/binarydeb/ros-noetic-ypspur-1.18.1/obj-x86_64-linux-gnu/include/config.h:5:76: error: missing terminating " character
In file included from /tmp/binarydeb/ros-noetic-ypspur-1.18.1/src/adinput.c:38:
/tmp/binarydeb/ros-noetic-ypspur-1.18.1/include/shvel-param.h:28:3: warning: data definition has no type or storage class
   28 | } Int_4Char;
      |   ^~~~~~~~~
/tmp/binarydeb/ros-noetic-ypspur-1.18.1/include/shvel-param.h:28:3: warning: type defaults to ‘int’ in declaration of ‘Int_4Char’ [-Wimplicit-int]
```

I don't know what changed since there's been no yp-spur release since the last successful build. Maybe there's a newer version of `git` in Ubuntu Focal that has this new error message?