### PR TITLE
Fix clock_nanosleep existence checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,12 +69,6 @@ check_function_exists(longjmp HAVE_LONGJMP)
 check_function_exists(siglongjmp HAVE_SIGLONGJMP)
 check_function_exists(clock_nanosleep HAVE_CLOCK_NANOSLEEP)
 
-add_compile_definitions(
-  HAVE_LONGJMP
-  HAVE_SIGLONGJMP
-  HAVE_CLOCK_NANOSLEEP
-)
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/include/config.h
 )
@@ -102,6 +96,7 @@ if(READLINE_FOUND)
   )
 endif(READLINE_FOUND)
 
+
 # Static link options
 
 option(ENABLE_ALL_STATIC "Static link libgcc and libstdc++." OFF)
@@ -111,6 +106,31 @@ if(ENABLE_ALL_STATIC)
   set(CMAKE_SHARED_LINKER_FLAGS "-static-libgcc")
   set(TARGET_STATIC_POSTFIX "-static")
 endif(ENABLE_ALL_STATIC)
+
+
+# Compile flags
+
+if(CMAKE_VERSION VERSION_LESS "3.12")
+  add_compile_definitions(
+    HAVE_LONGJMP
+    HAVE_SIGLONGJMP
+    HAVE_CLOCK_NANOSLEEP
+    HAVE_SSM
+  )
+else()
+  if(HAVE_LONGJMP)
+    add_definitions(-DHAVE_LONGJMP)
+  endif()
+  if(HAVE_SIGLONGJMP)
+    add_definitions(-DHAVE_SIGLONGJMP)
+  endif()
+  if(HAVE_CLOCK_NANOSLEEP)
+    add_definitions(-DHAVE_CLOCK_NANOSLEEP)
+  endif()
+  if(HAVE_SSM)
+    add_definitions(-DHAVE_SSM)
+  endif()
+endif()
 
 
 # Add subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,12 +124,18 @@ if(CMAKE_VERSION VERSION_LESS "3.12")
     add_definitions(-DHAVE_SSM)
   endif()
 else()
-  add_compile_definitions(
-    HAVE_LONGJMP
-    HAVE_SIGLONGJMP
-    HAVE_CLOCK_NANOSLEEP
-    HAVE_SSM
-  )
+  if(HAVE_LONGJMP)
+    add_compile_definitions(HAVE_LONGJMP)
+  endif()
+  if(HAVE_SIGLONGJMP)
+    add_compile_definitions(HAVE_SIGLONGJMP)
+  endif()
+  if(HAVE_CLOCK_NANOSLEEP)
+    add_compile_definitions(HAVE_CLOCK_NANOSLEEP)
+  endif()
+  if(HAVE_SSM)
+    add_compile_definitions(HAVE_SSM)
+  endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,13 +111,6 @@ endif(ENABLE_ALL_STATIC)
 # Compile flags
 
 if(CMAKE_VERSION VERSION_LESS "3.12")
-  add_compile_definitions(
-    HAVE_LONGJMP
-    HAVE_SIGLONGJMP
-    HAVE_CLOCK_NANOSLEEP
-    HAVE_SSM
-  )
-else()
   if(HAVE_LONGJMP)
     add_definitions(-DHAVE_LONGJMP)
   endif()
@@ -130,6 +123,13 @@ else()
   if(HAVE_SSM)
     add_definitions(-DHAVE_SSM)
   endif()
+else()
+  add_compile_definitions(
+    HAVE_LONGJMP
+    HAVE_SIGLONGJMP
+    HAVE_CLOCK_NANOSLEEP
+    HAVE_SSM
+  )
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,13 @@ endif(READLINE_FOUND)
 include(CheckFunctionExists)
 check_function_exists(longjmp HAVE_LONGJMP)
 check_function_exists(siglongjmp HAVE_SIGLONGJMP)
+check_function_exists(clock_nanosleep HAVE_CLOCK_NANOSLEEP)
+
+add_compile_definitions(
+  HAVE_LONGJMP
+  HAVE_SIGLONGJMP
+  HAVE_CLOCK_NANOSLEEP
+)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/include/config.h

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -11,10 +11,4 @@
 
 #cmakedefine YP_PARAMS_DIR "@YP_PARAMS_DIR@"
 
-#cmakedefine HAVE_SSM @HAVE_SSM@
-
-#cmakedefine HAVE_LONGJMP @HAVE_LONGJMP@
-
-#cmakedefine HAVE_SIGLONGJMP @HAVE_SIGLONGJMP@
-
 #endif

--- a/src/control_vehicle.c
+++ b/src/control_vehicle.c
@@ -503,7 +503,7 @@ void control_loop(void)
   yprintf(OUTPUT_LV_INFO, "Trajectory control loop started.\n");
   pthread_cleanup_push(control_loop_cleanup, NULL);
 
-#if defined(HAVE_LIBRT)  // clock_nanosleepが利用可能
+#if defined(HAVE_CLOCK_NANOSLEEP)  // clock_nanosleepが利用可能
   struct timespec request;
 
   if (clock_gettime(CLOCK_MONOTONIC, &request) == -1)
@@ -523,7 +523,7 @@ void control_loop(void)
 
     if ((option(OPTION_WITHOUT_DEVICE)))
     {
-      simulate_control(*odometry, spur);
+      simulate_control(odometry, spur);
     }
 
     // スレッドの停止要求チェック
@@ -547,7 +547,7 @@ void control_loop(void)
     // スレッドの停止要求チェック
     pthread_testcancel();
   }
-#endif  // defined(HAVE_LIBRT)
+#endif  // defined(HAVE_CLOCK_NANOSLEEP)
   pthread_cleanup_pop(1);
 }
 


### PR DESCRIPTION
Function existence check results haven't passed to compiler since migrated from automake to cmake.