### PR TITLE
Update required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.28)
 
 # Project version is automatically updated by the release candidate workflow
 project(ypspur VERSION 1.23.3)


### PR DESCRIPTION
Allow to use cmake compatibility mode up to 3.28 (locally tested) to avoid error/warning.
CMake 4.0 dropped 3.5 compatibility and marked 3.10 as deprecated.